### PR TITLE
WIP: impl scrollTo method that can be accessed via ref

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -265,6 +265,11 @@ export default class ScrollContainer extends PureComponent {
     this.forceUpdate()
   }
 
+  scrollTo(newClientX, newClientY) {
+    const container = this.container.current
+    container.scrollTo(newClientX, newClientY)
+  }
+
   render() {
     const {
       children, className, style, hideScrollbars

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,4 @@
-import { CSSProperties, FC, ReactNode } from "react";
+import { CSSProperties, FC, ReactNode, Ref } from "react";
 
 declare const ScrollContainer: FC<{
   vertical?: boolean;
@@ -28,6 +28,7 @@ declare const ScrollContainer: FC<{
   style?: CSSProperties;
   ignoreElements?: string;
   nativeMobileScroll?: boolean;
+  ref?: MutableRefObject<any>;
 }>;
 
 export default ScrollContainer;


### PR DESCRIPTION
Hi to all and thank you for your great library! This pull request provides a solution for https://github.com/Norserium/react-indiana-drag-scroll/issues/4

As findDOMNode() [has been deprecated in StrictMode](https://reactjs.org/docs/react-dom.html#finddomnode) I would suggest adding the `scrollTo` method to the `ScrollContainer`. It can be accessed via a ref to the `ScrollContainer`. If you are happy with this solution I can create an example and add documentation to the Readme.

With this solution one could set the start position from a parent container like shown in the example below:

```
const scrollContainerRef = useRef<any>(null);
const scrollContainer = scrollContainerRef.current;
scrollContainer.scrollTo(x,y);

------------
<ScrollContainer ref={scrollContainerRef}>...</ScrollContainer>
````

An alternative solution to this pull request would be to just use a ref to the `ScrollContainer` and access the internal `container` ref to call `scrollTo` of the DOM element. 
E.g.: 
```
const scrollContainerRef = useRef<any>(null);
const scrollContainer = scrollContainerRef.current;
const container = scrollContainer.container.current;
container.scrollTo(x,y)

------------
<ScrollContainer ref={scrollContainerRef}>...</ScrollContainer>
```

P.S.: I am new to react.js and happy about every feedback!