### PR TITLE
fix: remove React global referring

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-indiana-drag-scroll",
-  "version": "1.5.2",
+  "version": "1.5.4",
   "description": "Implements scroll on drag",
   "author": "Norserium",
   "license": "MIT",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,4 @@
-import { CSSProperties, ReactNode } from "react";
+import { Component, CSSProperties, ReactNode } from "react";
 
 export interface IScrollContainerProps {
   vertical?: boolean;
@@ -31,6 +31,6 @@ export interface IScrollContainerProps {
   ref?: ReactNode;
 }
 
-export default class ScrollContainer extends React.Component<IScrollContainerProps> {
+export default class ScrollContainer extends Component<IScrollContainerProps> {
   getElement: () => HTMLElement;
 }


### PR DESCRIPTION
While React is not imported obviously, you will get error on typescript type check:
```
'React' refers to a UMD global, but the current file is a module. Consider adding an import instead.
```
This PR fixes this issue