### PR TITLE
Add ignoredMouseButtons prop to control which buttons are ignored

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,21 +42,21 @@ class Example extends Component {
 
 ## Component properties
 
-| Prop                | Type          | Description                                                                               | Default |
-| ------------------- | ------------- | ----------------------------------------------------------------------------------------- | ------- |
-| vertical            | Bool          | Allow vertical drag scrolling                                                             | true    |
-| horizontal          | Bool          | Allow horizontal drag scrolling                                                           | true    |
-| hideScrollbars      | Bool          | Hide the scrollbars                                                                       | true    |
-| activationDistance  | Number        | The distance that distinguish click and drag start                                        | 10      |
-| children            | Node          | The content of scrolling container                                                        |
-| onScroll            | Function      | Invoked when user scrolling container                                                     |
-| onEndScroll         | Function      | Invoked when user ends scrolling container                                                |
-| onStartScroll       | Function      | Invoked when user starts scrolling container                                              |
-| className           | String        | The custom classname for container                                                        |
-| style               | Number        | The custom styles for container                                                           |
-| ignoreElements      | String        | Selector for elements that should not trigger the scrolling behaviour (for example, ".modal, dialog" or "\*[prevent-drag-scroll]") |
-| nativeMobileScroll  | Bool          | Use native mobile drag scroll for mobile devices                                          | true
-| ignoredMouseButtons | Array(Number) | Specify mouse buttons to ignore such as hardware forward/backward and right mouse         | [3, 4]
+| Prop               | Type          | Description                                                                               | Default |
+| ------------------ | ------------- | ----------------------------------------------------------------------------------------- | ------- |
+| vertical           | Bool          | Allow vertical drag scrolling                                                             | true    |
+| horizontal         | Bool          | Allow horizontal drag scrolling                                                           | true    |
+| hideScrollbars     | Bool          | Hide the scrollbars                                                                       | true    |
+| activationDistance | Number        | The distance that distinguish click and drag start                                        | 10      |
+| children           | Node          | The content of scrolling container                                                        |
+| onScroll           | Function      | Invoked when user scrolling container                                                     |
+| onEndScroll        | Function      | Invoked when user ends scrolling container                                                |
+| onStartScroll      | Function      | Invoked when user starts scrolling container                                              |
+| className          | String        | The custom classname for container                                                        |
+| style              | Number        | The custom styles for container                                                           |
+| ignoreElements     | String        | Selector for elements that should not trigger the scrolling behaviour (for example, ".modal, dialog" or "\*[prevent-drag-scroll]") |
+| nativeMobileScroll | Bool          | Use native mobile drag scroll for mobile devices                                          | true    |
+| ignoreMouseButtons | Array(Number) | Specify mouse buttons to ignore such as hardware forward/backward and right mouse         | [3, 4]  |
 
 ## Static functions
 

--- a/README.md
+++ b/README.md
@@ -42,20 +42,21 @@ class Example extends Component {
 
 ## Component properties
 
-| Prop               | Type     | Description                                                                               | Default |
-| ------------------ | -------- | ----------------------------------------------------------------------------------------- | ------- |
-| vertical           | Bool     | Allow vertical drag scrolling                                                             | true    |
-| horizontal         | Bool     | Allow horizontal drag scrolling                                                           | true    |
-| hideScrollbars     | Bool     | Hide the scrollbars                                                                       | true    |
-| activationDistance | Number   | The distance that distinguish click and drag start                                        | 10      |
-| children           | Node     | The content of scrolling container                                                        |
-| onScroll           | Function | Invoked when user scrolling container                                                     |
-| onEndScroll        | Function | Invoked when user ends scrolling container                                                |
-| onStartScroll      | Function | Invoked when user starts scrolling container                                              |
-| className          | String   | The custom classname for container                                                        |
-| style              | Number   | The custom styles for container                                                           |
-| ignoreElements     | String   | Selector for elements that should not trigger the scrolling behaviour (for example, ".modal, dialog" or "\*[prevent-drag-scroll]") |
-| nativeMobileScroll | Bool     | Use native mobile drag scroll for mobile devices                                          | true
+| Prop                | Type          | Description                                                                               | Default |
+| ------------------- | ------------- | ----------------------------------------------------------------------------------------- | ------- |
+| vertical            | Bool          | Allow vertical drag scrolling                                                             | true    |
+| horizontal          | Bool          | Allow horizontal drag scrolling                                                           | true    |
+| hideScrollbars      | Bool          | Hide the scrollbars                                                                       | true    |
+| activationDistance  | Number        | The distance that distinguish click and drag start                                        | 10      |
+| children            | Node          | The content of scrolling container                                                        |
+| onScroll            | Function      | Invoked when user scrolling container                                                     |
+| onEndScroll         | Function      | Invoked when user ends scrolling container                                                |
+| onStartScroll       | Function      | Invoked when user starts scrolling container                                              |
+| className           | String        | The custom classname for container                                                        |
+| style               | Number        | The custom styles for container                                                           |
+| ignoreElements      | String        | Selector for elements that should not trigger the scrolling behaviour (for example, ".modal, dialog" or "\*[prevent-drag-scroll]") |
+| nativeMobileScroll  | Bool          | Use native mobile drag scroll for mobile devices                                          | true
+| ignoredMouseButtons | Array(Number) | Specify mouse buttons to ignore such as hardware forward/backward and right mouse         | [3, 4]
 
 ## Static functions
 

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,7 @@ export default class ScrollContainer extends PureComponent {
     ignoreElements: PropTypes.string,
     nativeMobileScroll: PropTypes.bool,
     stopPropagation: PropTypes.bool,
-    ignoredMouseButtons: PropTypes.arrayOf(PropTypes.number)
+    ignoreMouseButtons: PropTypes.arrayOf(PropTypes.number)
   }
 
   static defaultProps = {
@@ -37,7 +37,7 @@ export default class ScrollContainer extends PureComponent {
     stopPropagation: false,
     style: {},
     // These are hardware forward/backward buttons
-    ignoredMouseButtons: [3, 4]
+    ignoreMouseButtons: [3, 4]
   }
 
   constructor(props) {
@@ -163,8 +163,8 @@ export default class ScrollContainer extends PureComponent {
   }
 
   onMouseDown = (e) => {
-    const { ignoredMouseButtons } = this.props
-    if (this.isDraggable(e.target) && !ignoredMouseButtons.includes(e.button)) {
+    const { ignoreMouseButtons } = this.props
+    if (this.isDraggable(e.target) && ignoreMouseButtons.indexOf(e.button) === -1) {
       this.processClick(e, e.clientX, e.clientY)
       e.preventDefault()
       if (this.props.stopPropagation) {

--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,8 @@ export default class ScrollContainer extends PureComponent {
     style: PropTypes.object,
     ignoreElements: PropTypes.string,
     nativeMobileScroll: PropTypes.bool,
-    stopPropagation: PropTypes.bool
+    stopPropagation: PropTypes.bool,
+    ignoredMouseButtons: PropTypes.arrayOf(PropTypes.number)
   }
 
   static defaultProps = {
@@ -34,7 +35,9 @@ export default class ScrollContainer extends PureComponent {
     vertical: true,
     horizontal: true,
     stopPropagation: false,
-    style: {}
+    style: {},
+    // These are hardware forward/backward buttons
+    ignoredMouseButtons: [3, 4]
   }
 
   constructor(props) {
@@ -160,7 +163,8 @@ export default class ScrollContainer extends PureComponent {
   }
 
   onMouseDown = (e) => {
-    if (this.isDraggable(e.target)) {
+    const { ignoredMouseButtons } = this.props
+    if (this.isDraggable(e.target) && !ignoredMouseButtons.includes(e.button)) {
       this.processClick(e, e.clientX, e.clientY)
       e.preventDefault()
       if (this.props.stopPropagation) {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -29,6 +29,7 @@ export interface IScrollContainerProps {
   ignoreElements?: string;
   nativeMobileScroll?: boolean;
   ref?: ReactNode;
+  ignoredMouseButtons?: Array<number>;
 }
 
 export default class ScrollContainer extends Component<IScrollContainerProps> {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -29,7 +29,7 @@ export interface IScrollContainerProps {
   ignoreElements?: string;
   nativeMobileScroll?: boolean;
   ref?: ReactNode;
-  ignoredMouseButtons?: Array<number>;
+  ignoreMouseButtons?: Array<number>;
 }
 
 export default class ScrollContainer extends Component<IScrollContainerProps> {


### PR DESCRIPTION
I have been using this library and I appreciate the work that went into it.

One issue I encountered when using it is that it intercepts the hardware forward/backward buttons on my mouse which I think is unexpected behavior. This adds a new prop, `ignoredMouseButtons` which allows specifying buttons to ignore. Alternatively this could be a whitelist but a blacklist seemed like the lower risk option of causing unexpected problems.