### PR TITLE
Add onClick prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ class Example extends Component {
 | onScroll           | Function | Invoked when user scrolling container                                                     |
 | onEndScroll        | Function | Invoked when user ends scrolling container                                                |
 | onStartScroll      | Function | Invoked when user starts scrolling container                                              |
+| onClick            | Function | Invoked when user clicks the scrolling container without dragging                         |
 | className          | String   | The custom classname for container                                                        |
 | style              | Number   | The custom styles for container                                                           |
 | ignoreElements     | String   | Selector for elements that should not trigger the scrolling behaviour (for example, ".modal, dialog" or "\*[prevent-drag-scroll]") |

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,7 @@ export default class ScrollContainer extends PureComponent {
     onStartScroll: PropTypes.func,
     onScroll: PropTypes.func,
     onEndScroll: PropTypes.func,
+    onClick: PropTypes.func,
     className: PropTypes.string,
     style: PropTypes.object,
     ignoreElements: PropTypes.string,
@@ -186,6 +187,9 @@ export default class ScrollContainer extends PureComponent {
       } else {
         this.pressed = false
         this.forceUpdate()
+        if (this.props.onClick) {
+          this.props.onClick(e)
+        }
       }
       e.preventDefault()
       if (this.props.stopPropagation) {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -24,6 +24,9 @@ export interface IScrollContainerProps {
     scrollWidth: number,
     scrollHeight: number
   ) => void;
+  onClick?: (
+    event: MouseEvent
+  ) => void;
   className?: string;
   style?: CSSProperties;
   ignoreElements?: string;


### PR DESCRIPTION
This addresses another need I had when using the library: I wanted to be able to handle a click that did not result in a drag. I tried adding an `onClick` handler to a parent div but this would be called after every drag.

This adds an `onClick` prop that is called when the user clicks without dragging to address this use case.